### PR TITLE
Update README to mention Caddy v1 to v2 migration changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,5 @@ You can replace `{env.CLOUDFLARE_API_TOKEN}` with the actual auth token if you p
 ## Authenticating
 
 See [the associated README in the libdns package](https://github.com/libdns/cloudflare) for important information about credentials.
+
+**NOTE**: If migrating from Caddy v1, you will need to change from using a Cloudflare API Key to a scoped API Token. Please see link above for more information.


### PR DESCRIPTION
Spent some time debugging a v1->v2 migration before finally groking the API token vs key discussion in #1 and stumbling upon https://github.com/libdns/cloudflare's helpful README image. Figured having a call-out for migrators like me might draw some added attention to the distnction.

Also probably worthwhile to add something to https://caddyserver.com/docs/modules/dns.providers.cloudflare explaining the difference as well when that gets fleshed out.