### PR TITLE
Fallback to env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ tls {
 
 You can replace `{env.CLOUDFLARE_API_TOKEN}` with the actual auth token if you prefer to put it directly in your config instead of an environment variable.
 
+Alternatively you can simply set the environment variable `CLOUDFLARE_API_TOKEN`, which this package will pick up if there is no token in the Caddy config file. 
 
 ## Authenticating
 

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -4,6 +4,7 @@ import (
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/libdns/cloudflare"
+	"os"
 )
 
 // Provider wraps the provider implementation as a Caddy module.
@@ -50,6 +51,9 @@ func (p *Provider) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				return d.Errf("unrecognized subdirective '%s'", d.Val())
 			}
 		}
+	}
+	if p.Provider.APIToken == "" {
+		p.Provider.APIToken = repl.ReplaceAll(os.Getenv("CLOUDFLARE_API_TOKEN"), "")
 	}
 	if p.Provider.APIToken == "" {
 		return d.Err("missing API token")


### PR DESCRIPTION
This PR allows for `CLOUDFLARE_API_TOKEN` to be specific as an environment variable. This useful as Caddy saves the final configuration as a JSON on disk. This avoids the token from being saved on the disk.