### PR TITLE
Update environment variable name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To use this module for the ACME DNS challenge, [configure the ACME issuer in you
 		"dns": {
 			"provider": {
 				"name": "cloudflare",
-				"api_token": "{env.CLOUDFLARE_API_TOKEN}"
+				"api_token": "{env.CF_API_TOKEN}"
 			}
 		}
 	}
@@ -31,11 +31,11 @@ or with the Caddyfile:
 
 ```
 tls {
-	dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+	dns cloudflare {env.CF_API_TOKEN}
 }
 ```
 
-You can replace `{env.CLOUDFLARE_API_TOKEN}` with the actual auth token if you prefer to put it directly in your config instead of an environment variable.
+You can replace `{env.CF_API_TOKEN}` with the actual auth token if you prefer to put it directly in your config instead of an environment variable.
 
 
 ## Authenticating


### PR DESCRIPTION
Most Cloudflare libraries standardized on `CF_API_TOKEN` as API token environment variables, best to follow suit.

Example: https://github.com/go-acme/lego/pull/937/files