### PR TITLE
Optional scoped API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,22 @@ This package contains a DNS provider module for [Caddy](https://github.com/caddy
 dns.providers.cloudflare
 ```
 
-## Config examples
+## Configuration
+
+This module gives the user two ways of configuring API tokens.
+
+1. Seperate Zone and DNS Tokens
+	- **Zone Token:** `Zone.Zone:Read` permission for `All zones`
+	- **DNS Token:** `Zone.DNS:Edit` permission for the domain you're managing with Caddy 
+2. Single API Token
+	- **API Token:** `Zone.Zone:Read` and `Zond.DNS:Edit` permissions for `All zones`
+
+If you host multiple DNS Zones (domains) in Cloudflare, strongly consider using option 1.
+
+Option 2 provides a simple way for users with a single domain. However, with this approach the key has permission to edit the DNS of **all** Zones in your account, so use this with care.
+
+
+### JSON Example
 
 To use this module for the ACME DNS challenge, [configure the ACME issuer in your Caddy JSON](https://caddyserver.com/docs/json/apps/tls/automation/policies/issuers/acme/) like so:
 
@@ -27,7 +42,20 @@ To use this module for the ACME DNS challenge, [configure the ACME issuer in you
 }
 ```
 
-or with the Caddyfile:
+### Caddyfile Examples
+
+#### Dual-key approach
+
+```
+tls {
+	dns cloudflare {
+		zone_token {env.CF_ZONE_TOKEN}
+		dns_token {env.CF_DNS_TOKEN}
+	}
+}
+```
+
+#### Single-key approach
 
 ```
 tls {
@@ -35,7 +63,7 @@ tls {
 }
 ```
 
-You can replace `{env.CF_API_TOKEN}` with the actual auth token if you prefer to put it directly in your config instead of an environment variable.
+You can replace the `{env.CF_*}` placeholders with the actual auth token if you prefer to put it directly in your config instead of an environment variable, however it is less secure.
 
 
 ## Authenticating

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To use this module for the ACME DNS challenge, [configure the ACME issuer in you
 
 #### Dual-key approach
 
-```
+```Caddyfile
 tls {
 	dns cloudflare {
 		zone_token {env.CF_ZONE_TOKEN}
@@ -57,7 +57,7 @@ tls {
 
 #### Single-key approach
 
-```
+```Caddyfile
 tls {
 	dns cloudflare {env.CF_API_TOKEN}
 }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To use this module for the ACME DNS challenge, [configure the ACME issuer in you
 tls {
 	dns cloudflare {
 		zone_token {env.CF_ZONE_TOKEN}
-		dns_token {env.CF_DNS_TOKEN}
+		api_token {env.CF_API_TOKEN}
 	}
 }
 ```

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -15,9 +15,9 @@
 package cloudflare
 
 import (
+	cloudflare "github.com/aliask/libdns-cloudflare"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
-	"github.com/libdns/cloudflare"
 )
 
 // Provider wraps the provider implementation as a Caddy module.
@@ -44,8 +44,10 @@ func (p *Provider) Provision(ctx caddy.Context) error {
 
 // UnmarshalCaddyfile sets up the DNS provider from Caddyfile tokens. Syntax:
 //
-//	cloudflare [<api_token>] {
-//	    api_token <api_token>
+//	cloudflare {
+//	    api_token <api_token> // or
+//	    dns_token <api_token>
+//	    zone_token <api_token>
 //	}
 //
 // Expansion of placeholders in the API token is left to the JSON config caddy.Provisioner (above).
@@ -67,13 +69,23 @@ func (p *Provider) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if d.NextArg() {
 					return d.ArgErr()
 				}
+			case "dns_token":
+				p.Provider.DNSToken = d.Val()
+				if d.NextArg() {
+					return d.ArgErr()
+				}
+			case "zone_token":
+				p.Provider.ZoneToken = d.Val()
+				if d.NextArg() {
+					return d.ArgErr()
+				}
 			default:
 				return d.Errf("unrecognized subdirective '%s'", d.Val())
 			}
 		}
 	}
-	if p.Provider.APIToken == "" {
-		return d.Err("missing API token")
+	if p.Provider.APIToken == "" || (p.Provider.DNSToken == "" && p.Provider.ZoneToken == "") {
+		return d.Err("missing API tokens")
 	}
 	return nil
 }

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -15,9 +15,9 @@
 package cloudflare
 
 import (
-	cloudflare "github.com/aliask/libdns-cloudflare"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/libdns/cloudflare"
 )
 
 // Provider wraps the provider implementation as a Caddy module.

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -40,7 +40,6 @@ func (Provider) CaddyModule() caddy.ModuleInfo {
 func (p *Provider) Provision(ctx caddy.Context) error {
 	p.Provider.APIToken = caddy.NewReplacer().ReplaceAll(p.Provider.APIToken, "")
 	p.Provider.ZoneToken = caddy.NewReplacer().ReplaceAll(p.Provider.ZoneToken, "")
-	p.Provider.DNSToken = caddy.NewReplacer().ReplaceAll(p.Provider.DNSToken, "")
 	return nil
 }
 
@@ -49,8 +48,8 @@ func (p *Provider) Provision(ctx caddy.Context) error {
 // Seperate Zone/DNS tokens
 //
 //	cloudflare {
+//	  api_token <api_token>     // Zone DNS write access - scoped to applicable Zone(s)
 //	  zone_token <zone_token>   // Zone read access - all zones
-//	  dns_token <dns_token>     // Zone DNS write access - scoped to applicable Zone(s)
 //	}
 //
 //	Single API Token
@@ -78,12 +77,6 @@ func (p *Provider) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				} else {
 					return d.ArgErr()
 				}
-			case "dns_token":
-				if d.NextArg() {
-					p.Provider.DNSToken = d.Val()
-				} else {
-					return d.ArgErr()
-				}
 			case "zone_token":
 				if d.NextArg() {
 					p.Provider.ZoneToken = d.Val()
@@ -98,17 +91,8 @@ func (p *Provider) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	if d.NextArg() {
 		return d.Errf("unexpected argument '%s'", d.Val())
 	}
-	if p.Provider.DNSToken != "" || p.Provider.ZoneToken != "" {
-		if p.Provider.ZoneToken == "" {
-			return d.Err("dns_token provided but no zone_token found")
-		}
-		if p.Provider.DNSToken == "" {
-			return d.Err("zone_token provided but no dns_token found")
-		}
-	} else {
-		if p.Provider.APIToken == "" {
-			return d.Err("missing API tokens")
-		}
+	if p.Provider.APIToken == "" {
+		return d.Err("missing API token")
 	}
 	return nil
 }

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	cloudflare "github.com/aliask/libdns-cloudflare"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/libdns/cloudflare"
 )
 
 func TestSingleArg(t *testing.T) {

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -62,23 +62,22 @@ func TestEmptyConfig(t *testing.T) {
 	err := p.UnmarshalCaddyfile(dispenser)
 	if err == nil {
 		t.Errorf(
-			"UnmarshalCaddyfile should have provided an error, but none was received. api_token = %s, zone_token = %s, dns_token = %s",
+			"UnmarshalCaddyfile should have provided an error, but none was received. api_token = %s, zone_token = %s",
 			p.Provider.APIToken,
 			p.Provider.ZoneToken,
-			p.Provider.DNSToken,
 		)
 	}
 }
 
-func TestZoneAndDNSTokens(t *testing.T) {
+func TestZoneAndAPITokens(t *testing.T) {
 	fmt.Println("Testing separated Zone and DNS tokens... ")
 	zone_token := "foo"
-	dns_token := "bar"
+	api_token := "bar"
 	config := fmt.Sprintf(`
 	cloudflare {
 		zone_token %s
-		dns_token %s
-	}`, zone_token, dns_token)
+		api_token %s
+	}`, zone_token, api_token)
 
 	dispenser := caddyfile.NewTestDispenser(config)
 	p := Provider{&cloudflare.Provider{}}
@@ -95,13 +94,7 @@ func TestZoneAndDNSTokens(t *testing.T) {
 		t.Errorf("Expected ZoneToken to be '%s' but got '%s'", expected, actual)
 	}
 
-	expected = dns_token
-	actual = p.Provider.DNSToken
-	if expected != actual {
-		t.Errorf("Expected DNSToken to be '%s' but got '%s'", expected, actual)
-	}
-
-	expected = ""
+	expected = api_token
 	actual = p.Provider.APIToken
 	if expected != actual {
 		t.Errorf("Expected APIToken to be '%s' but got '%s'", expected, actual)
@@ -110,12 +103,11 @@ func TestZoneAndDNSTokens(t *testing.T) {
 
 func TestPartialConfig(t *testing.T) {
 	fmt.Println("Testing partial config fails to parse... ")
-	dns_token := "bar"
+	zone_token := "bar"
 	config := fmt.Sprintf(`
 	cloudflare {
-		zone_token
-		dns_token %s
-	}`, dns_token)
+		zone_token %s
+	}`, zone_token)
 
 	dispenser := caddyfile.NewTestDispenser(config)
 	p := Provider{&cloudflare.Provider{}}
@@ -123,10 +115,9 @@ func TestPartialConfig(t *testing.T) {
 	err := p.UnmarshalCaddyfile(dispenser)
 	if err == nil {
 		t.Errorf(
-			"UnmarshalCaddyfile should have provided an error, but none was received. api_token = %s, zone_token = %s, dns_token = %s",
+			"UnmarshalCaddyfile should have provided an error, but none was received. api_token = %s, zone_token = %s",
 			p.Provider.APIToken,
 			p.Provider.ZoneToken,
-			p.Provider.DNSToken,
 		)
 	}
 }
@@ -142,10 +133,9 @@ func TestTooManyArgs(t *testing.T) {
 	err := p.UnmarshalCaddyfile(dispenser)
 	if err == nil {
 		t.Errorf(
-			"UnmarshalCaddyfile should have provided an error, but none was received. api_token = %s, zone_token = %s, dns_token = %s",
+			"UnmarshalCaddyfile should have provided an error, but none was received. api_token = %s, zone_token = %s",
 			p.Provider.APIToken,
 			p.Provider.ZoneToken,
-			p.Provider.DNSToken,
 		)
 	}
 }

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -1,0 +1,151 @@
+package cloudflare
+
+import (
+	"fmt"
+	"testing"
+
+	cloudflare "github.com/aliask/libdns-cloudflare"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+)
+
+func TestSingleArg(t *testing.T) {
+	fmt.Println("Testing single string argument (APIToken)... ")
+	api_token := "abc123"
+	config := fmt.Sprintf("cloudflare %s", api_token)
+
+	dispenser := caddyfile.NewTestDispenser(config)
+	p := Provider{&cloudflare.Provider{}}
+
+	err := p.UnmarshalCaddyfile(dispenser)
+	if err != nil {
+		t.Errorf("UnmarshalCaddyfile failed with %v", err)
+		return
+	}
+
+	expected := api_token
+	actual := p.Provider.APIToken
+	if expected != actual {
+		t.Errorf("Expected APIToken to be '%s' but got '%s'", expected, actual)
+	}
+}
+
+func TestAPITokenInBlock(t *testing.T) {
+	fmt.Println("Testing APIToken provided in block... ")
+	api_token := "abc123"
+	config := fmt.Sprintf(`cloudflare {
+		api_token %s
+	}`, api_token)
+
+	dispenser := caddyfile.NewTestDispenser(config)
+	p := Provider{&cloudflare.Provider{}}
+
+	err := p.UnmarshalCaddyfile(dispenser)
+	if err != nil {
+		t.Errorf("UnmarshalCaddyfile failed with %v", err)
+		return
+	}
+
+	expected := api_token
+	actual := p.Provider.APIToken
+	if expected != actual {
+		t.Errorf("Expected APIToken to be '%s' but got '%s'", expected, actual)
+	}
+}
+
+func TestEmptyConfig(t *testing.T) {
+	fmt.Println("Testing empty config fails to parse... ")
+	config := "cloudflare"
+
+	dispenser := caddyfile.NewTestDispenser(config)
+	p := Provider{&cloudflare.Provider{}}
+
+	err := p.UnmarshalCaddyfile(dispenser)
+	if err == nil {
+		t.Errorf(
+			"UnmarshalCaddyfile should have provided an error, but none was received. api_token = %s, zone_token = %s, dns_token = %s",
+			p.Provider.APIToken,
+			p.Provider.ZoneToken,
+			p.Provider.DNSToken,
+		)
+	}
+}
+
+func TestZoneAndDNSTokens(t *testing.T) {
+	fmt.Println("Testing separated Zone and DNS tokens... ")
+	zone_token := "foo"
+	dns_token := "bar"
+	config := fmt.Sprintf(`
+	cloudflare {
+		zone_token %s
+		dns_token %s
+	}`, zone_token, dns_token)
+
+	dispenser := caddyfile.NewTestDispenser(config)
+	p := Provider{&cloudflare.Provider{}}
+
+	err := p.UnmarshalCaddyfile(dispenser)
+	if err != nil {
+		t.Errorf("UnmarshalCaddyfile failed with %v", err)
+		return
+	}
+
+	expected := zone_token
+	actual := p.Provider.ZoneToken
+	if expected != actual {
+		t.Errorf("Expected ZoneToken to be '%s' but got '%s'", expected, actual)
+	}
+
+	expected = dns_token
+	actual = p.Provider.DNSToken
+	if expected != actual {
+		t.Errorf("Expected DNSToken to be '%s' but got '%s'", expected, actual)
+	}
+
+	expected = ""
+	actual = p.Provider.APIToken
+	if expected != actual {
+		t.Errorf("Expected APIToken to be '%s' but got '%s'", expected, actual)
+	}
+}
+
+func TestPartialConfig(t *testing.T) {
+	fmt.Println("Testing partial config fails to parse... ")
+	dns_token := "bar"
+	config := fmt.Sprintf(`
+	cloudflare {
+		zone_token
+		dns_token %s
+	}`, dns_token)
+
+	dispenser := caddyfile.NewTestDispenser(config)
+	p := Provider{&cloudflare.Provider{}}
+
+	err := p.UnmarshalCaddyfile(dispenser)
+	if err == nil {
+		t.Errorf(
+			"UnmarshalCaddyfile should have provided an error, but none was received. api_token = %s, zone_token = %s, dns_token = %s",
+			p.Provider.APIToken,
+			p.Provider.ZoneToken,
+			p.Provider.DNSToken,
+		)
+	}
+}
+
+func TestTooManyArgs(t *testing.T) {
+	fmt.Println("Testing too many args... ")
+	api_token := "foo"
+	config := fmt.Sprintf("cloudflare %s with more", api_token)
+
+	dispenser := caddyfile.NewTestDispenser(config)
+	p := Provider{&cloudflare.Provider{}}
+
+	err := p.UnmarshalCaddyfile(dispenser)
+	if err == nil {
+		t.Errorf(
+			"UnmarshalCaddyfile should have provided an error, but none was received. api_token = %s, zone_token = %s, dns_token = %s",
+			p.Provider.APIToken,
+			p.Provider.ZoneToken,
+			p.Provider.DNSToken,
+		)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
-module github.com/caddy-dns/cloudflare
+module github.com/aliask/caddy-cloudflare
 
 go 1.20
 
 require (
+	github.com/aliask/libdns-cloudflare v0.0.0-20240530215425-8e17dd5e7d5f
 	github.com/caddyserver/caddy/v2 v2.7.5
-	github.com/libdns/cloudflare v0.1.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aliask/caddy-cloudflare
 go 1.20
 
 require (
-	github.com/aliask/libdns-cloudflare v0.0.0-20240530215425-8e17dd5e7d5f
+	github.com/aliask/libdns-cloudflare v0.0.0-20240601015312-3ed679a9717f
 	github.com/caddyserver/caddy/v2 v2.7.5
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
-module github.com/aliask/caddy-cloudflare
+module github.com/caddy-dns/cloudflare
 
 go 1.20
 
 require (
-	github.com/aliask/libdns-cloudflare v0.0.0-20240601015312-3ed679a9717f
 	github.com/caddyserver/caddy/v2 v2.7.5
+	github.com/libdns/cloudflare v0.0.0-20240604123710-0549667a10ab
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aliask/libdns-cloudflare v0.0.0-20240530215425-8e17dd5e7d5f h1:gFxUFBdI34BhAUgLCjQ/rcQw7l++Fi+XDqseaMTOSeQ=
-github.com/aliask/libdns-cloudflare v0.0.0-20240530215425-8e17dd5e7d5f/go.mod h1:ja8JGK6PxlvvR4Aow1Mu5f6us1LOhARlisgpxNQFFfI=
+github.com/aliask/libdns-cloudflare v0.0.0-20240601015312-3ed679a9717f h1:adHcBfahob6mFMqVN6xHKVv/YLjaw8LJDXTtU0uihps=
+github.com/aliask/libdns-cloudflare v0.0.0-20240601015312-3ed679a9717f/go.mod h1:ja8JGK6PxlvvR4Aow1Mu5f6us1LOhARlisgpxNQFFfI=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aliask/libdns-cloudflare v0.0.0-20240601015312-3ed679a9717f h1:adHcBfahob6mFMqVN6xHKVv/YLjaw8LJDXTtU0uihps=
-github.com/aliask/libdns-cloudflare v0.0.0-20240601015312-3ed679a9717f/go.mod h1:ja8JGK6PxlvvR4Aow1Mu5f6us1LOhARlisgpxNQFFfI=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -32,6 +30,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
+github.com/libdns/cloudflare v0.0.0-20240604123710-0549667a10ab h1:y7j8QRb3JC0E5asccjelEuVHLfLXk/jpVIWDW9eII1k=
+github.com/libdns/cloudflare v0.0.0-20240604123710-0549667a10ab/go.mod h1:9VK91idpOjg6v7/WbjkEW49bSCxj00ALesIFDhJ8PBU=
 github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
 github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/aliask/libdns-cloudflare v0.0.0-20240530215425-8e17dd5e7d5f h1:gFxUFBdI34BhAUgLCjQ/rcQw7l++Fi+XDqseaMTOSeQ=
+github.com/aliask/libdns-cloudflare v0.0.0-20240530215425-8e17dd5e7d5f/go.mod h1:ja8JGK6PxlvvR4Aow1Mu5f6us1LOhARlisgpxNQFFfI=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -30,8 +32,6 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
-github.com/libdns/cloudflare v0.1.1 h1:FVPfWwP8zZCqj268LZjmkDleXlHPlFU9KC4OJ3yn054=
-github.com/libdns/cloudflare v0.1.1/go.mod h1:9VK91idpOjg6v7/WbjkEW49bSCxj00ALesIFDhJ8PBU=
 github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
 github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=


### PR DESCRIPTION
## Overview

This PR allows for a second API token to be optionally configured, used for fetching info about the Zones in Cloudflare.

The change is backwards compatible with existing configs - if the Zone API token is not provided, the regular API token is used for all requests.

## Why

The `/zones` API endpoint requires that the entire token be scoped globally, which then means that the DNS edit permission must also be scoped globally. This prevents the use of a single API token to perform DNS updates to be restricted to a single zone in a multi-zone account.

By splitting the token out, this global scoped token can be left as read-only, and the DNS read/write token can be scoped to a single Zone.

I believe this should address #2 (at least the original issue, I think there might be a separate issue being discussed in the comments)

## Testing

I've written some small tests for this module which can be run with `go test`. I believe these tests cover the old Caddyfile syntax as well as the updated one with two tokens.

## TODO

- [ ] If `libdns/cloudflare` gets a release tag then `go.mod` can be updated to target this instead of the manual git SHA
- [ ] Actual real-world tests with old configs to ensure that nothing breaks