### PR TITLE
ci: fix the pipeline by upgrading default installed go version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,8 @@
 name: Continuous Integration
 
 on:
+  schedule:
+    - cron: "0 7 * * *"
   push:
     branches:
       - main

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,9 +18,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: '1.24.2'
+          check-latest: true
 
       - name: Cache Go modules
         uses: actions/cache@v3


### PR DESCRIPTION
- The current version fails because the `actions/setup-go@v4` does not support toolchain switching. This PR updates to `v5`, which allows this.
- Also added a daily build to notice regressions if a Caddy update breaks the Cloudflare integration.

PS: Sorry, I should have checked the build error message before opening the previous PR #103 