### PR TITLE
fix invalid maximum length of CF API token

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -23,8 +23,8 @@ import (
 	"github.com/libdns/cloudflare"
 )
 
-// cloudflareTokenRegexp matches Cloudflare tokens consisting of 35 to 50 alphanumeric characters, dashes, or underscores.
-var cloudflareTokenRegexp = regexp.MustCompile(`^[A-Za-z0-9_-]{35,50}$`)
+// cloudflareTokenRegexp matches Cloudflare tokens consisting of 35 to 54 alphanumeric characters, dashes, or underscores.
+var cloudflareTokenRegexp = regexp.MustCompile(`^[A-Za-z0-9_-]{35,54}$`)
 
 // Provider wraps the provider implementation as a Caddy module.
 type Provider struct{ *cloudflare.Provider }


### PR DESCRIPTION
I had problem with using this module and I find out that CF is generating longer API token that is allowed in cloudflareTokenRegexp, so I fixed it :)