### PR TITLE
Accept Cloudflare cfut_/cfat_ API tokens

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -23,8 +23,11 @@ import (
 	"github.com/libdns/cloudflare"
 )
 
-// cloudflareTokenRegexp matches Cloudflare tokens consisting of 35 to 50 alphanumeric characters, dashes, or underscores.
-var cloudflareTokenRegexp = regexp.MustCompile(`^[A-Za-z0-9_-]{35,50}$`)
+// legacyCloudflareTokenRegexp matches classic API tokens: 35–50 alphanumeric, dash, or underscore.
+var legacyCloudflareTokenRegexp = regexp.MustCompile(`^[A-Za-z0-9_-]{35,50}$`)
+
+// newCloudflareTokenRegexp matches user (cfut_) and account (cfat_) API token formats.
+var newCloudflareTokenRegexp = regexp.MustCompile(`^cf(ut|at)_[A-Za-z0-9_-]{32,256}$`)
 
 // Provider wraps the provider implementation as a Caddy module.
 type Provider struct{ *cloudflare.Provider }
@@ -52,9 +55,9 @@ func (p *Provider) Provision(ctx caddy.Context) error {
 	return nil
 }
 
-// validCloudflareToken validates if the provided token matches the expected Cloudflare token format using a regular expression.
+// validCloudflareToken returns true for legacy API tokens (35–50 chars) or cfut_/cfat_ tokens.
 func validCloudflareToken(token string) bool {
-	return cloudflareTokenRegexp.MatchString(token)
+	return newCloudflareTokenRegexp.MatchString(token) || legacyCloudflareTokenRegexp.MatchString(token)
 }
 
 // UnmarshalCaddyfile sets up the DNS provider from Caddyfile tokens. Three syntaxes supported:

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/caddyserver/caddy/v2"
@@ -149,6 +150,8 @@ func TestInvalidTokens(t *testing.T) {
 		`"Sqqty8-Vn0iOP29rvqYgwKz_xqGQ4y5JhuVL1-qU"`,
 		"Sqqty8-Vn0iOP29rvqYgwKz_xqGQ4y5JhuVL1-qU-extra-characters-that-are-way-too-long",
 		"abcdef",
+		// cfut_/cfat_ with suffix >256 (too long for new; too long for legacy)
+		"cfut_" + strings.Repeat("a", 257),
 	}
 
 	for _, badToken := range badTokens {
@@ -160,6 +163,39 @@ func TestInvalidTokens(t *testing.T) {
 			)
 		}
 	}
+}
+
+func TestValidCloudflareTokenFormats(t *testing.T) {
+	validAPITokens := []string{
+		// legacy
+		"Sqqty8-Vn0iOP29rvqYgwKz_xqGQ4y5JhuVL1-qU",
+		// user token (cfut_)
+		"cfut_6YNSv6zUiWehDxZfdh8vNf3orQJzA6rrcDFJhql65e203820",
+		// account token (cfat_)
+		"cfat_3Sak5MsJJAsXNHCEmRufjbkbrdcxrhZFofmAe1pN435b71a9",
+		// minimum-length new-format suffix (32 chars)
+		"cfut_12345678901234567890123456789012",
+		"cfat_12345678901234567890123456789012",
+		// same shape as cfut_/cfat_ but 35–50 chars total → accepted as legacy
+		"cfut_123456789012345678901234567890",
+		"cfxt_12345678901234567890123456789012",
+	}
+
+	for _, tok := range validAPITokens {
+		t.Run(tok[:min(12, len(tok))]+"...", func(t *testing.T) {
+			p := Provider{&cloudflare.Provider{APIToken: tok}}
+			if err := p.Provision(caddy.Context{}); err != nil {
+				t.Errorf("Provision: %v", err)
+			}
+		})
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func TestValidToken(t *testing.T) {


### PR DESCRIPTION
Cloudflare introduced new token formats (user cfut_…, account cfat_…) alongside the existing legacy tokens. This PR extends provisioning validation so those shapes are accepted