### PR TITLE
Fix: increase API token regex limit to support longer cfut_ tokens

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -23,8 +23,8 @@ import (
 	"github.com/libdns/cloudflare"
 )
 
-// cloudflareTokenRegexp matches Cloudflare tokens consisting of 35 to 50 alphanumeric characters, dashes, or underscores.
-var cloudflareTokenRegexp = regexp.MustCompile(`^[A-Za-z0-9_-]{35,50}$`)
+// cloudflareTokenRegexp matches Cloudflare tokens consisting of 35 to 55 alphanumeric characters, dashes, or underscores.
+var cloudflareTokenRegexp = regexp.MustCompile(`^[A-Za-z0-9_-]{35,55}$`)
 
 // Provider wraps the provider implementation as a Caddy module.
 type Provider struct{ *cloudflare.Provider }


### PR DESCRIPTION
Cloudflare is issuing tokens with "cfut_" prefixes. The current regex check of 50 was causing an error saying the token was invalid. I tried generating multiple tokens and they were all 53 characters long with that prefix. 

Updating the regex check to 55 characters fixed the issue.