### PR TITLE
Update token regex

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -23,8 +23,8 @@ import (
 	"github.com/libdns/cloudflare"
 )
 
-// cloudflareTokenRegexp matches Cloudflare tokens consisting of 35 to 50 alphanumeric characters, dashes, or underscores.
-var cloudflareTokenRegexp = regexp.MustCompile(`^[A-Za-z0-9_-]{35,50}$`)
+// cloudflareTokenRegexp matches Cloudflare tokens consisting of 35 to 55 alphanumeric characters, dashes, or underscores.
+var cloudflareTokenRegexp = regexp.MustCompile(`^[A-Za-z0-9_-]{35,55}$`)
 
 // Provider wraps the provider implementation as a Caddy module.
 type Provider struct{ *cloudflare.Provider }


### PR DESCRIPTION
Newer tokens from Cloudflare are longer as they have a prefix to indicate user or account tokens. Increased regex from 50 to 55 characters to account for `cfut` or `cfat` (i think that was the one for accounts, but havent tested since early debug) prefix

see https://caddy.community/t/caddy-tailscale-cloudflare-certificate-issue/33585/5 for more details.

My setup did not work before, and now it worked flawlessly. Hopefully this can be merged , so I can point to an official release.

Thank you for your hard work on getting this all together, this bump was painful but nothing compared to the work put in by the devs of caddy and caddy-cloudflare.